### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Banzai
 
 [![Build Status](https://travis-ci.org/twneale/banzai.svg?branch=master)](https://travis-ci.org/twneale/banzai)
 [![Coverage Status](https://coveralls.io/repos/twneale/banzai/badge.png?branch=master)](https://coveralls.io/r/twneale/banzai?branch=master)
-[![Latest Version](https://pypip.in/version/banzai/badge.png)](https://pypi.python.org/pypi/banzai/)
-[![Download Format](https://pypip.in/format/banzai/badge.png)](https://pypi.python.org/pypi/banzai/)
+[![Latest Version](https://img.shields.io/pypi/v/banzai.svg
+[![Download Format](https://img.shields.io/pypi/format/banzai.svg
 
 Classes and a CLI tool for creating pipeline-based work flows.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Banzai
 
 [![Build Status](https://travis-ci.org/twneale/banzai.svg?branch=master)](https://travis-ci.org/twneale/banzai)
 [![Coverage Status](https://coveralls.io/repos/twneale/banzai/badge.png?branch=master)](https://coveralls.io/r/twneale/banzai?branch=master)
-[![Latest Version](https://img.shields.io/pypi/v/banzai.svg
-[![Download Format](https://img.shields.io/pypi/format/banzai.svg
+[![Latest Version](https://img.shields.io/pypi/v/banzai.svg)](https://pypi.python.org/pypi/banzai/)
+[![Download Format](https://img.shields.io/pypi/format/banzai.svg)](https://pypi.python.org/pypi/banzai/)
 
 Classes and a CLI tool for creating pipeline-based work flows.


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20banzai))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `banzai`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.